### PR TITLE
Adding generic type for UbudStorageModule

### DIFF
--- a/src/ubud/storage/src/lib/storage.module.ts
+++ b/src/ubud/storage/src/lib/storage.module.ts
@@ -14,7 +14,7 @@ export class UbudStorageModule {
         }
     }
 
-    public static forRoot(impl: Type<Storage>): ModuleWithProviders {
+    public static forRoot(impl: Type<Storage>): ModuleWithProviders<UbudStorageModule> {
         return {
             ngModule: UbudStorageModule,
             providers: [


### PR DESCRIPTION
Fixing error when running on Angular 10

Needs generic type on ModuleWithProviders class